### PR TITLE
fix: change baseUrl to / for private repo Pages URL

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -24,7 +24,7 @@ sites:
     url: https://pay.staging.alpacax.com/api/
 
 status-website:
-  baseUrl: /alpacon-status-dev
+  baseUrl: /
   name: Alpacon Status (Dev)
   introTitle: "**Alpacon** Dev/Staging 환경 상태 모니터링"
   introMessage: AlpacaX dev/staging 서비스의 실시간 상태를 확인할 수 있습니다.

--- a/history/account-service.yml
+++ b/history/account-service.yml
@@ -1,7 +1,7 @@
 url: https://account.staging.alpacax.com
 status: up
 code: 200
-responseTime: 639
-lastUpdated: 2026-03-13T05:03:27.360Z
+responseTime: 790
+lastUpdated: 2026-03-13T05:06:54.158Z
 startTime: 2026-03-13T04:43:14.081Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/alpaca-x-web.yml
+++ b/history/alpaca-x-web.yml
@@ -1,7 +1,7 @@
 url: https://staging.alpacax.com/
 status: up
 code: 403
-responseTime: 580
-lastUpdated: 2026-03-13T05:03:23.702Z
+responseTime: 651
+lastUpdated: 2026-03-13T05:06:51.112Z
 startTime: 2026-03-13T04:43:06.818Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/alpacon-dev-api.yml
+++ b/history/alpacon-dev-api.yml
@@ -1,7 +1,7 @@
 url: https://dev.alpacon.io/api/
 status: up
 code: 200
-responseTime: 119
-lastUpdated: 2026-03-13T05:03:26.523Z
+responseTime: 118
+lastUpdated: 2026-03-13T05:06:53.168Z
 startTime: 2026-03-13T04:43:13.527Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/alpacon-dev.yml
+++ b/history/alpacon-dev.yml
@@ -1,7 +1,7 @@
 url: https://dev.alpacon.io/alpacax
 status: up
 code: 200
-responseTime: 551
-lastUpdated: 2026-03-13T05:03:26.205Z
+responseTime: 558
+lastUpdated: 2026-03-13T05:06:52.850Z
 startTime: 2026-03-13T04:43:12.285Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/alpacon-docs.yml
+++ b/history/alpacon-docs.yml
@@ -1,7 +1,7 @@
 url: https://docs.staging.alpacax.com/
 status: up
 code: 403
-responseTime: 669
-lastUpdated: 2026-03-13T05:03:24.583Z
+responseTime: 763
+lastUpdated: 2026-03-13T05:06:52.086Z
 startTime: 2026-03-13T04:43:09.523Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/payment-api.yml
+++ b/history/payment-api.yml
@@ -1,7 +1,7 @@
 url: https://pay.staging.alpacax.com/api/
 status: up
 code: 200
-responseTime: 155
-lastUpdated: 2026-03-13T05:03:28.613Z
+responseTime: 175
+lastUpdated: 2026-03-13T05:06:55.562Z
 startTime: 2026-03-13T04:43:16.569Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/payment-web.yml
+++ b/history/payment-web.yml
@@ -1,7 +1,7 @@
 url: https://pay.staging.alpacax.com/
 status: up
 code: 200
-responseTime: 695
-lastUpdated: 2026-03-13T05:03:28.260Z
+responseTime: 824
+lastUpdated: 2026-03-13T05:06:55.185Z
 startTime: 2026-03-13T04:43:15.326Z
 generator: Upptime <https://github.com/upptime/upptime>


### PR DESCRIPTION
## Summary
- Private repo GitHub Pages deploys to `*.pages.github.io` root
- Changed `baseUrl: /alpacon-status-dev` → `baseUrl: /` to fix 404

## Root Cause
Private repos use a random URL root instead of org-based subpath, so the subpath setting was pointing to a wrong path causing 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)