### PR TITLE
chore: limit past incidents to 10

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -29,6 +29,7 @@ status-website:
   name: Alpacon Status (Dev)
   introTitle: "**Alpacon** Dev/Staging 환경 상태 모니터링"
   introMessage: AlpacaX dev/staging 서비스의 실시간 상태를 확인할 수 있습니다.
+  maxPastIncidents: 10
   navbar:
     - title: Status
       href: /

--- a/history/account-service.yml
+++ b/history/account-service.yml
@@ -1,7 +1,7 @@
 url: https://account.staging.alpacax.com
 status: up
 code: 200
-responseTime: 610
-lastUpdated: 2026-03-13T05:30:17.343Z
+responseTime: 593
+lastUpdated: 2026-03-13T05:41:32.750Z
 startTime: 2026-03-13T04:43:14.081Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/alpaca-x-web.yml
+++ b/history/alpaca-x-web.yml
@@ -2,6 +2,6 @@ url: https://staging.alpacax.com/
 status: up
 code: 403
 responseTime: 456
-lastUpdated: 2026-03-13T05:30:14.608Z
+lastUpdated: 2026-03-13T05:41:30.391Z
 startTime: 2026-03-13T04:43:06.818Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/alpacon-dev-api.yml
+++ b/history/alpacon-dev-api.yml
@@ -1,7 +1,7 @@
 url: https://dev.alpacon.io/api/
 status: up
 code: 200
-responseTime: 52
-lastUpdated: 2026-03-13T05:30:16.202Z
+responseTime: 56
+lastUpdated: 2026-03-13T05:41:31.972Z
 startTime: 2026-03-13T04:43:13.527Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/alpacon-dev.yml
+++ b/history/alpacon-dev.yml
@@ -1,7 +1,7 @@
 url: https://dev.alpacon.io/alpacax
 status: up
 code: 200
-responseTime: 426
-lastUpdated: 2026-03-13T05:30:15.946Z
+responseTime: 495
+lastUpdated: 2026-03-13T05:41:31.731Z
 startTime: 2026-03-13T04:43:12.285Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/alpacon-docs.yml
+++ b/history/alpacon-docs.yml
@@ -1,7 +1,7 @@
 url: https://docs.staging.alpacax.com/
 status: up
 code: 403
-responseTime: 516
-lastUpdated: 2026-03-13T05:30:15.322Z
+responseTime: 471
+lastUpdated: 2026-03-13T05:41:31.050Z
 startTime: 2026-03-13T04:43:09.523Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/payment-api.yml
+++ b/history/payment-api.yml
@@ -1,7 +1,7 @@
 url: https://pay.staging.alpacax.com/api/
 status: up
 code: 200
-responseTime: 142
-lastUpdated: 2026-03-13T05:30:18.577Z
+responseTime: 138
+lastUpdated: 2026-03-13T05:41:34.005Z
 startTime: 2026-03-13T04:43:16.569Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/payment-web.yml
+++ b/history/payment-web.yml
@@ -1,7 +1,7 @@
 url: https://pay.staging.alpacax.com/
 status: up
 code: 200
-responseTime: 642
-lastUpdated: 2026-03-13T05:30:18.237Z
+responseTime: 603
+lastUpdated: 2026-03-13T05:41:33.543Z
 startTime: 2026-03-13T04:43:15.326Z
 generator: Upptime <https://github.com/upptime/upptime>


### PR DESCRIPTION
## Summary
- Added `maxPastIncidents: 10` to limit Past Incidents section to the 10 most recent

🤖 Generated with [Claude Code](https://claude.com/claude-code)