### PR TITLE
chore: remove secrets section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,6 @@ With [Upptime](https://upptime.js.org), you can get your own unlimited and free 
 
 [**Visit our status website →**](https://alpacax.github.io/alpacon-status-dev)
 
-## Secrets
-
-| Secret Name | Description                                                         | Source                                                |
-| ----------- | ------------------------------------------------------------------- | ----------------------------------------------------- |
-| `GH_PAT`    | Upptime이 repo에 상태 데이터를 커밋하고 Issues를 생성하기 위한 토큰 | Fine-grained PAT `UPPTIME_STATUS_TOKEN` (alpacax org) |
-
 ## 📄 License
 
 - Powered by: [Upptime](https://github.com/upptime/upptime)


### PR DESCRIPTION
## Summary
- Public repo에서 시크릿 관련 내용(GH_PAT, PAT 이름 등) 노출 방지를 위해 Secrets 섹션 삭제

🤖 Generated with [Claude Code](https://claude.com/claude-code)