### PR TITLE
Fix navbar Status link pointing to wrong URL

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -35,6 +35,6 @@ status-website:
   maxPastIncidents: 10
   navbar:
     - title: Status
-      href: /
+      href: /alpacon-status-dev
     - title: GitHub
       href: https://github.com/$OWNER/$REPO


### PR DESCRIPTION
## Summary
- Fixed the Status link in the navbar that navigated to `alpacax.github.io/` instead of `alpacax.github.io/alpacon-status-dev/`
- Changed `href: /` to `href: /alpacon-status-dev` to match the baseUrl

## Test plan
- [ ] Click "Status" in the navbar on the status page and verify it stays on `/alpacon-status-dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)