### PR TITLE
Remove navbar title text

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -26,7 +26,7 @@ sites:
 status-website:
   publish: true
   baseUrl: /alpacon-status-dev
-  name: Alpacon Status (Dev)
+  name: ""
   logoUrl: https://raw.githubusercontent.com/alpacax/alpacon-status-dev/master/assets/logo.svg
   favicon: https://raw.githubusercontent.com/alpacax/alpacon-status-dev/master/assets/icon.svg
   faviconSvg: https://raw.githubusercontent.com/alpacax/alpacon-status-dev/master/assets/icon.svg


### PR DESCRIPTION
## Summary
- Remove "Alpacon Status (Dev)" text from the navbar header
- The AlpacaX logo already identifies the service, making the text redundant

## Test plan
- [ ] Verify the navbar shows only the logo without extra text

🤖 Generated with [Claude Code](https://claude.com/claude-code)