### PR TITLE
Add noindex meta tag to prevent search engine indexing

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -30,6 +30,7 @@ status-website:
   logoUrl: https://raw.githubusercontent.com/alpacax/alpacon-status-dev/master/assets/logo.svg
   favicon: https://raw.githubusercontent.com/alpacax/alpacon-status-dev/master/assets/icon.svg
   faviconSvg: https://raw.githubusercontent.com/alpacax/alpacon-status-dev/master/assets/icon.svg
+  customHeadHtml: '<meta name="robots" content="noindex, nofollow">'
   introTitle: "**Alpacon** Dev/Staging Status Monitor"
   introMessage: Real-time status of AlpacaX dev/staging services.
   maxPastIncidents: 10


### PR DESCRIPTION
## Summary
- Add `<meta name="robots" content="noindex, nofollow">` via `customHeadHtml` config
- Prevents dev status page from being indexed by search engines, avoiding it ranking higher than the future production status page

## Note
- `robots.txt` is not viable here because this is a project site at a subpath (`alpacax.github.io/alpacon-status-dev/`), and robots.txt only works at the domain root
- Meta tag approach works regardless of URL path

## Test plan
- [ ] Verify `<meta name="robots" content="noindex, nofollow">` appears in the page source after site rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)